### PR TITLE
Client tries to send messages before the connections are ready

### DIFF
--- a/src/logic/connection.js
+++ b/src/logic/connection.js
@@ -172,6 +172,11 @@ export class Connection {
       }
       if (!!payload) {
         Object.entries(this.clients).forEach(([sid, conns]) => {
+          if (conns.dc.readyState !== 'open') {
+            reject(`Data channel not open for ${sid}`);
+          } else {
+            conns.dc.send(payload);
+          }
           conns.dc.send(payload);
         });
         resolve();

--- a/src/logic/gamestate.js
+++ b/src/logic/gamestate.js
@@ -78,6 +78,8 @@ export class GameState extends EventEmitter {
         }
       };
       this._connection.sendGameMessage(payload).then(() => {
+      }).catch((e) => {
+        console.log(e);
       });
     });
   }
@@ -114,6 +116,8 @@ export class GameState extends EventEmitter {
       this.players['player'].status = status;
       this._connection.sendGameMessage({ type: 'status', data: data }).then(() => {
         this.emit('status-change', 'player', status);
+      }).catch((e) => {
+        console.log(e);
       });
     });
   }

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -51,7 +51,7 @@ export class Game extends Scene {
       this.doMovement(player, direction);
     });
     this.gameState.on('player-leaves', (playerid) => {
-      this.gameState.players[playerid].object.destroy();
+      this.gameState.players[playerid]?.object?.destroy();
     });
     this.gameState.on('status-change', (playerid, status) => {
       switch (status) {


### PR DESCRIPTION
Sometimes client loads the game faster than the connections are ready. At first I tried to check the connections when joining the room. Of course they aren't announced by then and client loads the game instantly. At least now there is a check that message will be sent only when connection status is open. This means that some attempted messages won't be sent.